### PR TITLE
Fixed cred loader split to only delimiter first :

### DIFF
--- a/meris_checker.py
+++ b/meris_checker.py
@@ -35,7 +35,7 @@ def credentials_loader():
                    for x in read_file('credentials.txt').split("\n")
                    if len(x.strip()) != 0]
 
-    split_credentials = [x.split(":") for x in credentials]
+    split_credentials = [x.split(":", 1) for x in credentials]
 
     return split_credentials
 


### PR DESCRIPTION
I ran into an issue with a randomly generated password for the Mikrotik admin that caused the PoC to not be able to authenticate. Turned out that the password had a colon in it and line 38 was splitting it into 3 parts instead of 'username','password'

Changed split maxsplit to 1 so any occurrences of a colon in the actual password will be ignored. Tested to work both with and without a colon in the password now.